### PR TITLE
add missing cl class object to bulmaTextInput

### DIFF
--- a/R/bulma-input.R
+++ b/R/bulma-input.R
@@ -114,6 +114,8 @@ bulmaTextInput <- function(inputId, label = NULL, placeholder = "", color = NULL
     div <- shiny::tagAppendChild(div, label)
   }
   
+  cl <- "input shinybulmaTextInput"
+  
   if(!is.null(color))
     cl <- paste0(cl, " is-", color)
   


### PR DESCRIPTION
Just downloaded the latest dev version and got `object 'cl' not found` errors on textInputs so I've added it in.