### PR TITLE
Fix #19 width parameter not respected

### DIFF
--- a/R/bulma-tiles.R
+++ b/R/bulma-tiles.R
@@ -69,7 +69,7 @@ bulmaTileParent <- function(..., vertical = FALSE, width = NULL){
   cl <-"tile is-parent"
   
   if(isTRUE(vertical)) cl <- paste(cl, "is-vertical")
-  if(!is.null(width)) cl <- paste0(cl, " is-")
+  if(!is.null(width)) cl <- paste0(cl, " is-", width)
   
   shiny::tags$div(
     class = cl,


### PR DESCRIPTION
The width parameter was not respected for bulmaTileParent. This was
due to the missing `width` parameter in the `paste0` command.
This commit fixes this small issue.