### PR TITLE
Add possibility to not wrap bulmaActionButton

### DIFF
--- a/R/bulma-input.R
+++ b/R/bulma-input.R
@@ -271,6 +271,7 @@ bulmaSelectInput <- function(inputId, label, choices, rounded = FALSE){
 #' @param inputId the input slot that will be used to access the value.
 #' @param color button color.
 #' @param label button label.
+#' @param wrap  if `TRUE` the button is wrapped in a `div(..., class = "control")` element.
 #'
 #' @examples
 #' if(interactive()){
@@ -287,22 +288,26 @@ bulmaSelectInput <- function(inputId, label, choices, rounded = FALSE){
 #' }
 #' @author John Coene, \email{jcoenep@@gmail.com}
 #' @export
-bulmaActionButton <- function(inputId, label, color = NULL){
-
+bulmaActionButton <- function(inputId, label, color = NULL, wrap = TRUE){
+  
   cl <- "button shinyBulmaActionButton"
-
+  
   if(!is.null(color)) cl <- paste0(cl, " is-", color)
-
-  button <- shiny::tags$div(
-    class = "control",
-    shiny::tags$button(
-      id = inputId,
-      class = cl,
-      value = 0,
-      label
-    )
+  
+  button <-  shiny::tags$button(
+    id = inputId,
+    class = cl,
+    value = 0,
+    label
   )
-
+  
+  if (wrap) {
+    button <- shiny::tags$div(
+      class = "control",
+      button
+    )
+  }
+  
   return(button)
 }
 

--- a/man/bulmaActionButton.Rd
+++ b/man/bulmaActionButton.Rd
@@ -4,7 +4,7 @@
 \alias{bulmaActionButton}
 \title{Add action button}
 \usage{
-bulmaActionButton(inputId, label, color = NULL)
+bulmaActionButton(inputId, label, color = NULL, wrap = TRUE)
 }
 \arguments{
 \item{inputId}{the input slot that will be used to access the value.}
@@ -12,6 +12,8 @@ bulmaActionButton(inputId, label, color = NULL)
 \item{label}{button label.}
 
 \item{color}{button color.}
+
+\item{wrap}{if `TRUE` the button is wrapped in a `div(..., class = "control")` element.}
 }
 \description{
 Add an action button.


### PR DESCRIPTION
The actionButton is wrapped by default in a div(.., class = "control")
element. In this commit we add a new optional parameter to skip this.
In this way we can place the button next to a heading and mimic more
the original actionButton.

Closes #24.