### PR TITLE
Fix slider input

### DIFF
--- a/R/bulma-input.R
+++ b/R/bulma-input.R
@@ -538,6 +538,7 @@ bulmaSliderInput <- function(inputId, value, min, max, color = NULL, step = 1, c
     step = step,
     min = min,
     max = max,
+    value = value,
     style = "width: 100%;",
     orient = orient,
     ...


### PR DESCRIPTION
A small bug prevented the slider input to show the value on startup.
The reason was that the parameter was not passed on to teh `tags$input`.

This closes #26.