### PR TITLE
Fix tabs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Bulma for Shiny
 Version: 0.0.2.9000
 Authors@R: c(person("John", "Coene", email = "jcoenep@gmail.com", role = c("aut", "cre")),
   person("David", "Granjon", email = "david.granjon@uzh.ch", role = "aut", comment = "bulma-extensions"),
-  person("Thorn", "Thaler", email = "thorn.thaler@thothal.at", rolw = "aut"),
+  person("Thorn", "Thaler", email = "thorn.thaler@thothal.at", role = "aut"),
   person(family = "RinteRface", role = "cph")
   )
 Description: Bulma for Shiny. Contains also an implementation of some of the major components

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Bulma for Shiny
 Version: 0.0.2.9000
 Authors@R: c(person("John", "Coene", email = "jcoenep@gmail.com", role = c("aut", "cre")),
   person("David", "Granjon", email = "david.granjon@uzh.ch", role = "aut", comment = "bulma-extensions"),
-  person("Thorn", "Thaler", email = "thorn.thaler@thothal.at", role = "aut"),
+  person("Thorn", "Thaler", email = "thorn.thaler@thothal.at", role = "ctb"),
   person(family = "RinteRface", role = "cph")
   )
 Description: Bulma for Shiny. Contains also an implementation of some of the major components

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinybulma
 Title: Bulma for Shiny
-Version: 0.0.1
+Version: 0.0.2.9000
 Authors@R: c(person("John", "Coene", email = "jcoenep@gmail.com", role = c("aut", "cre")),
   person("David", "Granjon", email = "david.granjon@uzh.ch", role = "aut", comment = "bulma-extensions"),
   person(family = "RinteRface", role = "cph")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,6 +3,7 @@ Title: Bulma for Shiny
 Version: 0.0.2.9000
 Authors@R: c(person("John", "Coene", email = "jcoenep@gmail.com", role = c("aut", "cre")),
   person("David", "Granjon", email = "david.granjon@uzh.ch", role = "aut", comment = "bulma-extensions"),
+  person("Thorn", "Thaler", email = "thorn.thaler@thothal.at", rolw = "aut"),
   person(family = "RinteRface", role = "cph")
   )
 Description: Bulma for Shiny. Contains also an implementation of some of the major components

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# shinybulma 0.0.2.9000
+
+* Bump bulma to `0.9.1`
+* Bump themes to `0.8.2`
+* Bump fontawesome to `5.15.1`
+
 # shinybulma 0.0.1
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/bulma-input.R
+++ b/R/bulma-input.R
@@ -538,6 +538,7 @@ bulmaSliderInput <- function(inputId, value, min, max, color = NULL, step = 1, c
     step = step,
     min = min,
     max = max,
+    value = value,
     style = "width: 100%;",
     orient = orient,
     ...

--- a/inst/js-0.7.2/bulma-tabs-js.js
+++ b/inst/js-0.7.2/bulma-tabs-js.js
@@ -1,3 +1,7 @@
 $( function() {
   $( ".bulmaTabs" ).tabs();
+  $(".tabs li[role = 'tab']").on("click", function() {
+     var $content = $($(this).children("a").attr("href"));
+     $content.find(".shiny-bound-output").trigger("shown");
+  });
 } );


### PR DESCRIPTION
Fix not shown output elments upon tab change

The default behaviour of shiny is not to show output elements (.shiny-bound-output) on hidden parts. These elements are only shown when the respective part is shown. This is implemented by listening to the `shown` event, which needs to be triggered to inform Shiny that an element is now visible.

The tab functionality is implemented using jquery ui. Since this library is of course not aware of the requirements of Shiny we have to  trigger a `shown` event manually in case we change a tab. This allows Shiny to show output elements when needed.

This closes #28.